### PR TITLE
updated the puppet scripts to remove the puppet deprecation warning 

### DIFF
--- a/provision/modules/mirrors/templates/saltstack-salt.list.erb
+++ b/provision/modules/mirrors/templates/saltstack-salt.list.erb
@@ -1,1 +1,1 @@
-deb http://ppa.launchpad.net/saltstack/salt/ubuntu <%= lsbdistcodename %> main
+deb http://ppa.launchpad.net/saltstack/salt/ubuntu <%= @lsbdistcodename %> main

--- a/provision/modules/networking/templates/hosts.erb
+++ b/provision/modules/networking/templates/hosts.erb
@@ -1,9 +1,9 @@
 127.0.0.1       localhost
-127.0.1.1       <%= fqdn %>
+127.0.1.1       <%= @fqdn %>
 
-172.16.42.10 salt.<%= domain %> salt
-172.16.42.11 minion1.<%= domain %> minion1
-172.16.42.12 minion2.<%= domain %> minion2
+172.16.42.10 salt.<%= @domain %> salt
+172.16.42.11 minion1.<%= @domain %> minion1
+172.16.42.12 minion2.<%= @domain %> minion2
 
 # The following lines are desirable for IPv6 capable hosts
 # ::1     localhost ip6-localhost ip6-loopback


### PR DESCRIPTION
On Ubuntu 14.04 LTS I was getting these warnings: 

"Variable access via 'lsbdistcodename' is deprecated. Use '@lsbdistcodename' instead."
"Variable access via 'domain' is deprecated. Use '@domain' instead."
"Variable access via 'fqdn' is deprecated. Use '@fqdn' instead."